### PR TITLE
Github build action

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+	# required for vscode server:
+    git \
+    curl \
+    ca-certificates \
+	# cleanup:
+    && rm -rf /var/lib/apt/lists/*
+
+# Enable colors (Debian has them but disabled by default)
+ENV TERM=xterm-256color
+RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,3 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	# cleanup:
     && rm -rf /var/lib/apt/lists/*
 
-# Enable colors (Debian has them but disabled by default)
-ENV TERM=xterm-256color
-RUN sed -i 's/^#force_color_prompt=yes/force_color_prompt=yes/' /etc/skel/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "Rust",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer"
+			]
+		}
+	}
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,82 @@
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main]
+  # Uncomment below and remove push trigger when ready for release-only builds:
+  # push:
+  #   tags:
+  #     - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: opensnitch-tui-linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: opensnitch-tui-linux-aarch64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Configure linker for aarch64
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          mkdir -p .cargo
+          echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        run: |
+          cp target/${{ matrix.target }}/release/opensnitch-tui ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  # Uncomment this job when ready to create releases on tags:
+  # release:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: startsWith(github.ref, 'refs/tags/')
+  #   permissions:
+  #     contents: write
+  #   steps:
+  #     - name: Download artifacts
+  #       uses: actions/download-artifact@v4
+  #
+  #     - name: Create release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         files: |
+  #           opensnitch-tui-linux-x86_64/opensnitch-tui-linux-x86_64
+  #           opensnitch-tui-linux-aarch64/opensnitch-tui-linux-aarch64

--- a/README.md
+++ b/README.md
@@ -38,7 +38,33 @@ The instructions above apply when the OpenSnitch daemon and GUI/TUI are running 
 
 **Note that only one of the GUI or TUI can run at one time, so kill the `opensnitch-ui` or `opensnitch-tui` process to run the other.**
 
-### Build and Run
+### Pre-built Binaries
+
+Download the latest release for your architecture:
+
+```sh
+# x86_64
+curl -fsSL https://github.com/amalbansode/opensnitch-tui/releases/latest/download/opensnitch-tui-linux-x86_64 -o opensnitch-tui
+chmod +x opensnitch-tui
+
+# aarch64 (ARM64)
+curl -fsSL https://github.com/amalbansode/opensnitch-tui/releases/latest/download/opensnitch-tui-linux-aarch64 -o opensnitch-tui
+chmod +x opensnitch-tui
+```
+
+Or in a Dockerfile:
+
+```dockerfile
+# x86_64
+RUN curl -fsSL https://github.com/amalbansode/opensnitch-tui/releases/latest/download/opensnitch-tui-linux-x86_64 -o /usr/local/bin/opensnitch-tui && \
+    chmod +x /usr/local/bin/opensnitch-tui
+
+# aarch64 (ARM64)
+RUN curl -fsSL https://github.com/amalbansode/opensnitch-tui/releases/latest/download/opensnitch-tui-linux-aarch64 -o /usr/local/bin/opensnitch-tui && \
+    chmod +x /usr/local/bin/opensnitch-tui
+```
+
+### Build from Source
 
 ```sh
 $ cd $THIS_REPO


### PR DESCRIPTION
Hello,

I was interested to help make a github action that built binaries for x64 and ARM64.

I added a devcontainer first, to make it simpler for me to work with. 
I'll understand if you'd prefer not to include this, but I needed it to so included it.

The github action is currently set to build on commit, for testing, if all okay this could be configured to create builds on tag release perhaps...
<img width="1278" height="904" alt="Screenshot 2025-12-08 at 20 20 20" src="https://github.com/user-attachments/assets/f767fcca-a25d-4e01-b15f-329bfd6fb1fa" />

No worries if this won't land as-is, I selfishly wanted something like this to remove the rust compile step from my project for this tool!
