### PR TITLE
🧀 🐁 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2024"
 
 [dependencies]
 futures = "0.3.31"
-crossterm = { version = "0.28.1", features = ["event-stream"] }
-ratatui = "0.29.0"
+crossterm = { version = "0.28.1", default-features = false, features = ["event-stream", "events"] }
+ratatui = { version = "0.29.0", default-features = false, features = ["crossterm"] }
 color-eyre = "0.6.3"
 tonic = "*"
 prost = "0.14.1"
@@ -19,3 +19,9 @@ clap = { version = "4.5.53", features = ["wrap_help"] }
 
 [build-dependencies]
 tonic-prost-build = "*"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ tonic-prost-build = "*"
 [profile.release]
 strip = true
 lto = true
-codegen-units = 1
 opt-level = "z"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ pub mod serde_impl;
 pub mod server;
 pub mod ui;
 
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+
 /// Main.
 /// # Errors
 /// Returns an error if there was bad input at init.
@@ -21,6 +24,7 @@ async fn main() -> color_eyre::Result<()> {
 
     color_eyre::install()?;
     let terminal = ratatui::init();
+    execute!(std::io::stdout(), EnableMouseCapture)?;
     let app = app::App::new(
         matches.get_one::<String>("ip_port").unwrap(),
         matches.get_one::<String>("default_action").unwrap(),
@@ -29,6 +33,7 @@ async fn main() -> color_eyre::Result<()> {
     )
     .expect("Initialization failed: ");
     let result = app.run(terminal).await;
+    let _ = execute!(std::io::stdout(), DisableMouseCapture);
     ratatui::restore();
     result
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,7 +12,7 @@ use crate::constants;
 const BUTTONS: &[(&str, constants::Action, constants::Duration)] = &[
     (" Allow(A) ", constants::Action::Allow, constants::Duration::UntilRestart),
     (" Deny(D) ", constants::Action::Deny, constants::Duration::UntilRestart),
-    (" Forever(J) ", constants::Action::Allow, constants::Duration::Always),
+    (" Always(J) ", constants::Action::Allow, constants::Duration::Always),
     (" Never(L) ", constants::Action::Deny, constants::Duration::Always),
 ];
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,10 +10,10 @@ use crate::constants;
 
 /// Button labels and their actions.
 const BUTTONS: &[(&str, constants::Action, constants::Duration)] = &[
-    (" Allow [A] ", constants::Action::Allow, constants::Duration::UntilRestart),
-    (" Deny [D] ", constants::Action::Deny, constants::Duration::UntilRestart),
-    (" Allow Forever [J] ", constants::Action::Allow, constants::Duration::Always),
-    (" Deny Forever [L] ", constants::Action::Deny, constants::Duration::Always),
+    (" Allow(A) ", constants::Action::Allow, constants::Duration::UntilRestart),
+    (" Deny(D) ", constants::Action::Deny, constants::Duration::UntilRestart),
+    (" Allow Forever(J) ", constants::Action::Allow, constants::Duration::Always),
+    (" Deny Forever(L) ", constants::Action::Deny, constants::Duration::Always),
 ];
 
 impl Widget for &App {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -223,7 +223,7 @@ impl App {
                 let src = format!("{}:{}", info.connection.src_ip, info.connection.src_port);
                 let dst = format!("{}:{}", info.connection.dst_ip, info.connection.dst_port);
                 format!(
-                    "\n{}\n{} → {} [{}]\nuid:{} pid:{} {}",
+                    "\n{}\n{} → {} [{}]\nuid:{} pid:{} ppath:{}",
                     dst_host,
                     src,
                     dst,


### PR DESCRIPTION
Okay, so this might be horrible, but I wanted mouse support in my devcontainer for this, so I made some tweaks.

<img width="982" height="348" alt="Screenshot 2025-12-09 at 21 51 55" src="https://github.com/user-attachments/assets/c6b58b95-33d5-4fda-ba69-24a3b4819bce" />

Garish and ugly for now, but very obvious in my devcontainer scenario. Needs some 'sexy tui' design thinking.

At some point it will be really cool to be able to navigate through a queue of connections.

Figured I may as well share it with you.

How I'm currently using opensnitch-tui:
<img width="1402" height="544" alt="Screenshot 2025-12-09 at 22 01 40" src="https://github.com/user-attachments/assets/64c89dc5-de1e-45e1-8f88-ed47592015ed" />
